### PR TITLE
Add production server URL to Swagger documentation

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,10 @@ const swaggerOptions = {
         url: "http://localhost:3000",
         description: "Local development server",
       },
+      {
+        url: "https://webshop-api-wc6u.onrender.com",
+        description: "Production server (Render)",
+      },
     ],
     components: {
       securitySchemes: {


### PR DESCRIPTION
add multiple server URLs in Swagger config

- Updated Swagger configuration to include both local (localhost:3000) and production (Render) server URLs.
- Now users can switch between local and deployed API in Swagger UI.
- Improved API documentation accessibility.